### PR TITLE
Feature/multiline completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For the moment, this extension contains the following features:
 
 ✅ Development and production bundles handled by `Webpack`
 
-✅ Providing arguments documentation when hovering on action's arguments
+✅ Providing documentation when hovering on action's arguments if available
 
 `In Progress`: Autocompletion for actions argument, providing default value if speicified in `fastlane` action config item.
 

--- a/src/client/src/providers/ActionCompletionProvider.ts
+++ b/src/client/src/providers/ActionCompletionProvider.ts
@@ -50,6 +50,9 @@ class ActionCompletionProvider
     if (matchMulti) {
       const functionBlock = matchMulti[0];
       console.log({functionBlock});
+      const actionNameMatch = functionBlock.match(/^\s*([a-z_]+)/i);
+      const actionName = actionNameMatch ? actionNameMatch[1] : null;
+      console.log({ actionName });
       // Now you can do something with functionBlock...
     }
 

--- a/src/client/src/providers/ActionCompletionProvider.ts
+++ b/src/client/src/providers/ActionCompletionProvider.ts
@@ -89,7 +89,7 @@ class ActionCompletionProvider
     );
     console.log({remainingArgs});
     const completionItems = remainingArgs.map((arg) =>
-      this.generateArgument(arg)
+      this.generateArgument(arg, true)
     );
     return completionItems;
   }
@@ -169,8 +169,9 @@ class ActionCompletionProvider
       .join(", ");
     return `${configItem.key}: { ${entries} }`;
   }
-  private handleConfigDefaultValue(configItem: FastlaneConfigType) {
+  private handleConfigDefaultValue(configItem: FastlaneConfigType, lineBreakRequired = false) {
     let defaultValue = configItem.key + ': ${1:"your_' + configItem.key + '"}';
+    const lineBreak = lineBreakRequired ? '\n' : '';
 
     switch (configItem.data_type) {
       case "String":
@@ -178,21 +179,21 @@ class ActionCompletionProvider
         if (configItem.default_value) {
           if (typeof configItem.default_value === "object") {
             if (this.isEmpty(configItem.default_value)) {
-              defaultValue = configItem.key + ": ${1:{}}";
+              defaultValue = lineBreak + configItem.key + ": ${1:{}}";
               break;
             }
-            defaultValue = this.generateRubyHash(configItem);
+            defaultValue = lineBreak + this.generateRubyHash(configItem);
             break;
           }
           defaultValue =
-            configItem.key + ': ${1:"' + configItem.default_value + '"}';
+          lineBreak + configItem.key + ': ${1:"' + configItem.default_value + '"}';
         }
         break;
       case "Fastlane::Boolean":
       case "Integer":
         if (typeof configItem.default_value !== "undefined") {
           defaultValue =
-            configItem.key + ": ${1:" + configItem.default_value + "}";
+          lineBreak + configItem.key + ": ${1:" + configItem.default_value + "}";
         }
         break;
       case "Array":
@@ -200,18 +201,18 @@ class ActionCompletionProvider
           const defaultValueArray = configItem.default_value
             .map((value: string) => `"${value}"`)
             .join(", ");
-          defaultValue = configItem.key + ": ${1:[" + defaultValueArray + "]}";
+          defaultValue = lineBreak + configItem.key + ": ${1:[" + defaultValueArray + "]}";
           break;
         }
-        defaultValue = configItem.key + ": ${1:[]}";
+        defaultValue = lineBreak + configItem.key + ": ${1:[]}";
         break;
     }
     return new SnippetString(defaultValue);
   }
-  generateArgument(fastalneArg: FastlaneConfigType): CompletionItem {
+  generateArgument(fastalneArg: FastlaneConfigType, lineBreakRequired = false): CompletionItem {
     const argName = fastalneArg.key;
     const arg = new CompletionItem(argName, CompletionItemKind.Property);
-    const defaultValues = this.handleConfigDefaultValue(fastalneArg);
+    const defaultValues = this.handleConfigDefaultValue(fastalneArg, lineBreakRequired);
     arg.insertText = defaultValues;
     if (fastalneArg.description) {
       arg.documentation = new MarkdownString(fastalneArg.description);

--- a/src/client/src/providers/ActionCompletionProvider.ts
+++ b/src/client/src/providers/ActionCompletionProvider.ts
@@ -150,16 +150,15 @@ class ActionCompletionProvider
     const linePrefix = document
       .lineAt(position)
       .text.substring(0, position.character);
-    const completionItems = this.singleLineSearch(linePrefix);
-    if (!completionItems) {
-      // If there is no results for the singleLineSearch we fallback to multiline search
-      console.log("going for multiline search");
-      const multileSearchItems = this.multilineSearch(document, position);
-      if(multileSearchItems){
-        return multileSearchItems;
+      let completionItems = this.singleLineSearch(linePrefix);
+
+      if (!completionItems) {
+        console.log("going for multiline search");
+        completionItems = this.multilineSearch(document, position);
       }
-    }
-    return completionItems;
+    
+      // Ensure that we always return an array
+      return completionItems ?? [];
   }
   private isEmpty(obj: object): boolean {
     return Object.keys(obj).length === 0;

--- a/src/client/src/providers/ActionCompletionProvider.ts
+++ b/src/client/src/providers/ActionCompletionProvider.ts
@@ -33,10 +33,10 @@ class ActionCompletionProvider
   }
   public registerProvider(context: ExtensionContext): void {
     context.subscriptions.push(
-      languages.registerCompletionItemProvider("ruby", this, ...["(", ","])
+      languages.registerCompletionItemProvider("ruby", this, ...["(", ",", "\n"])
     );
   }
-  private multilineSearch(document: TextDocument, position: Position) {
+  private multilineSearch(document: TextDocument, position: Position, context: CompletionContext) {
     const actionNameTest = "slack";
     const regex = new RegExp(
       `\\b${actionNameTest}\\s*\\(\\s*([\\s\\S]*?)\\)`,
@@ -89,8 +89,12 @@ class ActionCompletionProvider
     );
     console.log({remainingArgs});
     const completionItems = remainingArgs.map((arg) =>
-      this.generateArgument(arg, true)
+      this.generateArgument(arg)
     );
+      if(context.triggerCharacter){
+        console.log("CHARACTER TRIGGERED");
+        console.log({triggerCharacter:context.triggerCharacter });
+      }
     return completionItems;
   }
   private getBlockHeight(block: string): number {
@@ -154,7 +158,7 @@ class ActionCompletionProvider
 
       if (!completionItems) {
         console.log("going for multiline search");
-        completionItems = this.multilineSearch(document, position);
+        completionItems = this.multilineSearch(document, position, context);
       }
     
       // Ensure that we always return an array

--- a/src/client/src/providers/ActionCompletionProvider.ts
+++ b/src/client/src/providers/ActionCompletionProvider.ts
@@ -45,7 +45,14 @@ class ActionCompletionProvider
     //Math.max(0, position.line - 1)
     // TODO: fix to do - Issue with text range
     const matchMulti = document
-      .getText(new Range(position.line - this.multilineBlockLength, 0, document.lineCount, 0))
+      .getText(
+        new Range(
+          position.line - this.multilineBlockLength,
+          0,
+          document.lineCount,
+          0
+        )
+      )
       .match(regex);
     console.log({ matchMulti });
     if (matchMulti) {
@@ -59,19 +66,37 @@ class ActionCompletionProvider
         console.log({ multilineArgs });
         const blockHeight = this.getBlockHeight(functionBlock);
         this.multilineBlockLength = blockHeight;
-        console.log({blockHeight});
+        console.log({ blockHeight });
+        const actionElement = actions_list.filter(
+          (element) => element.action_name === actionName
+        );
+        if (!actionElement.length) {
+          return null;
+        }
+
+        const actionArgs = actionElement[0].args;
+        if (!actionArgs) {
+          return null;
+        }
+        const remainingArgs = actionArgs.filter(
+          (arg) => !multilineArgs.includes(arg.key)
+        );
+
+        const completionItems = remainingArgs.map((arg) =>
+          this.generateArgument(arg)
+        );
+        return completionItems;
       }
     }
   }
   private getBlockHeight(block: string): number {
     const matches = block.match(/\n/g);
     // If there are no matches, it means that the block is a single line,
-    // so we return 1. Otherwise, we add 1 to the number of matches because 
+    // so we return 1. Otherwise, we add 1 to the number of matches because
     // there is one more line than there are line breaks.
     return matches ? matches.length + 1 : 1;
-}
-  private singleLineSearch(searchItem:string) {
-
+  }
+  private singleLineSearch(searchItem: string) {
     const matchAction = /[a-z_]+\s*\(\s*([^)]*)$/;
     const match = searchItem.match(matchAction);
 
@@ -106,7 +131,7 @@ class ActionCompletionProvider
     const completionItems = remainingArgs.map((arg) =>
       this.generateArgument(arg)
     );
-    console.log({existingArgs});
+    console.log({ existingArgs });
     this.multilineBlockLength = existingArgs.length;
     return completionItems;
   }
@@ -122,10 +147,10 @@ class ActionCompletionProvider
       .lineAt(position)
       .text.substring(0, position.character);
     const completionItems = this.singleLineSearch(linePrefix);
-    if(!completionItems){
+    if (!completionItems) {
       // If there is no results for the singleLineSearch we fallback to multiline search
       console.log("going for multiline search");
-      this.multilineSearch(document,position);
+      this.multilineSearch(document, position);
     }
     return completionItems;
   }

--- a/src/client/src/providers/ActionCompletionProvider.ts
+++ b/src/client/src/providers/ActionCompletionProvider.ts
@@ -37,9 +37,9 @@ class ActionCompletionProvider
     );
   }
   private multilineSearch(document: TextDocument, position: Position) {
-    const actionName = "slack";
+    const actionNameTest = "slack";
     const regex = new RegExp(
-      `\\b${actionName}\\s*\\(\\s*([\\s\\S]*?)\\)`,
+      `\\b${actionNameTest}\\s*\\(\\s*([\\s\\S]*?)\\)`,
       "gm"
     );
     //Math.max(0, position.line - 1)
@@ -55,39 +55,43 @@ class ActionCompletionProvider
       )
       .match(regex);
     console.log({ matchMulti });
-    if (matchMulti) {
-      const functionBlock = matchMulti[0];
-      console.log({ functionBlock });
-      const actionNameMatch = functionBlock.match(/^\s*([a-z_]+)/i);
-      const actionName = actionNameMatch ? actionNameMatch[1] : null;
-      console.log({ actionName });
-      if (actionName) {
-        const multilineArgs = this.parseMultilineArgs(functionBlock);
-        console.log({ multilineArgs });
-        const blockHeight = this.getBlockHeight(functionBlock);
-        this.multilineBlockLength = blockHeight;
-        console.log({ blockHeight });
-        const actionElement = actions_list.filter(
-          (element) => element.action_name === actionName
-        );
-        if (!actionElement.length) {
-          return null;
-        }
-
-        const actionArgs = actionElement[0].args;
-        if (!actionArgs) {
-          return null;
-        }
-        const remainingArgs = actionArgs.filter(
-          (arg) => !multilineArgs.includes(arg.key)
-        );
-
-        const completionItems = remainingArgs.map((arg) =>
-          this.generateArgument(arg)
-        );
-        return completionItems;
-      }
+    if (!matchMulti) {
+      return null;
     }
+
+    const functionBlock = matchMulti[0];
+    console.log({ functionBlock });
+    const actionNameMatch = functionBlock.match(/^\s*([a-z_]+)/i);
+    const actionName = actionNameMatch ? actionNameMatch[1] : null;
+    console.log({ actionName });
+    if (!actionName) {
+      return null;
+    }
+
+    const multilineArgs = this.parseMultilineArgs(functionBlock);
+    console.log({ multilineArgs });
+    const blockHeight = this.getBlockHeight(functionBlock);
+    this.multilineBlockLength = blockHeight;
+    console.log({ blockHeight });
+    const actionElement = actions_list.filter(
+      (element) => element.action_name === actionName
+    );
+    if (!actionElement.length) {
+      return null;
+    }
+    console.log("FOUND MATCHING ELEMENT");
+    const actionArgs = actionElement[0].args;
+    if (!actionArgs) {
+      return null;
+    }
+    const remainingArgs = actionArgs.filter(
+      (arg) => !multilineArgs.includes(arg.key)
+    );
+    console.log({remainingArgs});
+    const completionItems = remainingArgs.map((arg) =>
+      this.generateArgument(arg)
+    );
+    return completionItems;
   }
   private getBlockHeight(block: string): number {
     const matches = block.match(/\n/g);
@@ -150,7 +154,10 @@ class ActionCompletionProvider
     if (!completionItems) {
       // If there is no results for the singleLineSearch we fallback to multiline search
       console.log("going for multiline search");
-      this.multilineSearch(document, position);
+      const multileSearchItems = this.multilineSearch(document, position);
+      if(multileSearchItems){
+        return multileSearchItems;
+      }
     }
     return completionItems;
   }

--- a/src/client/src/providers/ActionCompletionProvider.ts
+++ b/src/client/src/providers/ActionCompletionProvider.ts
@@ -88,8 +88,9 @@ class ActionCompletionProvider
       (arg) => !multilineArgs.includes(arg.key)
     );
     console.log({remainingArgs});
+    const isLineBreakRequired = context.triggerCharacter === "," ? true : false;
     const completionItems = remainingArgs.map((arg) =>
-      this.generateArgument(arg)
+      this.generateArgument(arg,isLineBreakRequired)
     );
       if(context.triggerCharacter){
         console.log("CHARACTER TRIGGERED");

--- a/src/client/src/providers/ActionCompletionProvider.ts
+++ b/src/client/src/providers/ActionCompletionProvider.ts
@@ -170,8 +170,8 @@ class ActionCompletionProvider
     return `${configItem.key}: { ${entries} }`;
   }
   private handleConfigDefaultValue(configItem: FastlaneConfigType, lineBreakRequired = false) {
-    let defaultValue = configItem.key + ': ${1:"your_' + configItem.key + '"}';
     const lineBreak = lineBreakRequired ? '\n' : '';
+    let defaultValue = lineBreak + configItem.key + ': ${1:"your_' + configItem.key + '"}';
 
     switch (configItem.data_type) {
       case "String":
@@ -210,6 +210,7 @@ class ActionCompletionProvider
     return new SnippetString(defaultValue);
   }
   generateArgument(fastalneArg: FastlaneConfigType, lineBreakRequired = false): CompletionItem {
+    // Issue with fastalneArg.data_type "String" when string template "your_value" is displayed the linebreak is not triggered
     const argName = fastalneArg.key;
     const arg = new CompletionItem(argName, CompletionItemKind.Property);
     const defaultValues = this.handleConfigDefaultValue(fastalneArg, lineBreakRequired);

--- a/src/client/src/providers/ActionCompletionProvider.ts
+++ b/src/client/src/providers/ActionCompletionProvider.ts
@@ -55,20 +55,10 @@ class ActionCompletionProvider
       }
     }
   }
-  provideCompletionItems(
-    document: TextDocument,
-    position: Position,
-    token: CancellationToken,
-    context: CompletionContext
-  ): ProviderResult<CompletionItem[] | CompletionList<CompletionItem>> {
-    // get all text until the `position` and check if it reads `console.`
-    // and if so then complete if `log`, `warn`, and `error`
-    const linePrefix = document
-      .lineAt(position)
-      .text.substring(0, position.character);
+  private singleLineSearch(searchItem:string) {
 
     const matchAction = /[a-z_]+\s*\(\s*([^)]*)$/;
-    const match = linePrefix.match(matchAction);
+    const match = searchItem.match(matchAction);
 
     if (!match) {
       return null;
@@ -76,13 +66,11 @@ class ActionCompletionProvider
 
     const existingArgsLine = match[1];
     const existingArgs = this.parseArgs(existingArgsLine);
-    // console.log({ existingArgs });
     const actionPattern =
       /(\b[a-z]+(?:_[a-z]+)*\b)(?=\s*\(|\s*\(\s*\)|\s*\(\s*\w+\s*:\s*\w+\s*(?:,\s*\w+\s*:\s*\w+\s*)*\)|$)/;
 
-    const matchActionName = actionPattern.exec(linePrefix.trim());
+    const matchActionName = actionPattern.exec(searchItem.trim());
     if (!matchActionName || matchActionName.length < 1) {
-      //console.log({ matchActionName });
       return null;
     }
     const extractedActionName = matchActionName[1];
@@ -103,7 +91,20 @@ class ActionCompletionProvider
     const completionItems = remainingArgs.map((arg) =>
       this.generateArgument(arg)
     );
-    //console.log("returning items", completionItems);
+    return completionItems;
+  }
+  provideCompletionItems(
+    document: TextDocument,
+    position: Position,
+    token: CancellationToken,
+    context: CompletionContext
+  ): ProviderResult<CompletionItem[] | CompletionList<CompletionItem>> {
+    // get all text until the `position` and check if it reads `console.`
+    // and if so then complete if `log`, `warn`, and `error`
+    const linePrefix = document
+      .lineAt(position)
+      .text.substring(0, position.character);
+    const completionItems = this.singleLineSearch(linePrefix);
     return completionItems;
   }
   private isEmpty(obj: object): boolean {

--- a/src/client/src/providers/ActionCompletionProvider.ts
+++ b/src/client/src/providers/ActionCompletionProvider.ts
@@ -48,12 +48,12 @@ class ActionCompletionProvider
       "gm"
     );
     //Math.max(0, position.line - 1)
+    // TODO: fix to do - Issue with text range
     const matchMulti = document
-      .getText(new Range(position.line - 1, 0, document.lineCount, 0))
+      .getText(new Range(position.line - 5, 0, document.lineCount, 0))
       .match(regex);
     console.log({ matchMulti });
     if (matchMulti) {
-      // TODO: fix - if the completion handler is triggered on a new line with nothing on it, it does not match anything
       const functionBlock = matchMulti[0];
       console.log({ functionBlock });
       const actionNameMatch = functionBlock.match(/^\s*([a-z_]+)/i);

--- a/src/client/src/providers/ActionCompletionProvider.ts
+++ b/src/client/src/providers/ActionCompletionProvider.ts
@@ -11,6 +11,7 @@ import {
   MarkdownString,
   Position,
   ProviderResult,
+  Range,
   SnippetString,
   TextDocument,
   languages,
@@ -39,8 +40,20 @@ class ActionCompletionProvider
     // get all text until the `position` and check if it reads `console.`
     // and if so then complete if `log`, `warn`, and `error`
     const linePrefix = document
-      .lineAt(position)
-      .text.substring(0, position.character);
+    .lineAt(position)
+    .text.substring(0, position.character);
+    const actionName = "slack";
+    const regex =new RegExp(`\\b${actionName}\\s*\\(\\s*([\\s\\S]*?)\\)`, 'gm');
+    //Math.max(0, position.line - 1)
+    const matchMulti = document.getText(new Range(position.line - 1, 0, document.lineCount, 0)).match(regex);
+    console.log({matchMulti});
+    if (matchMulti) {
+      const functionBlock = matchMulti[0];
+      console.log({functionBlock});
+      // Now you can do something with functionBlock...
+    }
+
+
     const matchAction = /[a-z_]+\s*\(\s*([^)]*)$/;
     const match = linePrefix.match(matchAction);
 

--- a/src/client/src/providers/ActionCompletionProvider.ts
+++ b/src/client/src/providers/ActionCompletionProvider.ts
@@ -31,17 +31,7 @@ class ActionCompletionProvider
       languages.registerCompletionItemProvider("ruby", this, ...["(", ","])
     );
   }
-  provideCompletionItems(
-    document: TextDocument,
-    position: Position,
-    token: CancellationToken,
-    context: CompletionContext
-  ): ProviderResult<CompletionItem[] | CompletionList<CompletionItem>> {
-    // get all text until the `position` and check if it reads `console.`
-    // and if so then complete if `log`, `warn`, and `error`
-    const linePrefix = document
-      .lineAt(position)
-      .text.substring(0, position.character);
+  private multilineSearch(document: TextDocument, position: Position) {
     const actionName = "slack";
     const regex = new RegExp(
       `\\b${actionName}\\s*\\(\\s*([\\s\\S]*?)\\)`,
@@ -64,6 +54,18 @@ class ActionCompletionProvider
         console.log({ existingArgs });
       }
     }
+  }
+  provideCompletionItems(
+    document: TextDocument,
+    position: Position,
+    token: CancellationToken,
+    context: CompletionContext
+  ): ProviderResult<CompletionItem[] | CompletionList<CompletionItem>> {
+    // get all text until the `position` and check if it reads `console.`
+    // and if so then complete if `log`, `warn`, and `error`
+    const linePrefix = document
+      .lineAt(position)
+      .text.substring(0, position.character);
 
     const matchAction = /[a-z_]+\s*\(\s*([^)]*)$/;
     const match = linePrefix.match(matchAction);


### PR DESCRIPTION
# Features completed

Added basic support for autcompletion for single line and multiline context

## Remarks

There are still some imperfections. 

For example if a "," is missing at the last argument and the user goes on the next line, the completion is still triggered

```
slack(param1: value1,
   param2: value2
   *completion is triggered*
)
```

The completion is also triggered and active after as user types a comma after a closing parenthesis.
```
  action_name(param1: value1),
```



